### PR TITLE
feat: add g:pydocstring_enable_mapping option

### DIFF
--- a/doc/pydocstring.txt
+++ b/doc/pydocstring.txt
@@ -161,6 +161,16 @@ g:pydocstring_enable_comment			*g:pydocstring_enable_comment*
 
 		Default value is '1'
 
+g:pydocstring_enable_mapping			*g:pydocstring_enable_mapping*
+		Disable this option to prevent pydocstring from creating any
+		key mapping to the `:Pydocstring` command.
+		Note: this value is overridden if you explicitly create a
+		mapping in your vimrc, such as if you do:
+
+    nmap <silent> <C-m> <Plug>(pydocstring)
+
+		Default value is '1'
+
 ==============================================================================
 EXAMPLE						*pydocstring-vim-example*
 
@@ -195,6 +205,10 @@ Override default mapping.
   Following setting map <C-m> to generate docstring.
 
     nmap <silent> <C-m> <Plug>(pydocstring)
+
+  To disable mappings entirely, add the following to your .vimrc or _vimrc.
+
+    let g:pydocstring_enable_mapping = 0
 
 
 ==============================================================================

--- a/ftplugin/python/pydocstring.vim
+++ b/ftplugin/python/pydocstring.vim
@@ -10,9 +10,15 @@ set cpo&vim
 
 command! -nargs=0 -buffer -complete=customlist,pydocstring#insert Pydocstring call pydocstring#insert()
 
-nnoremap <silent> <buffer> <Plug>(pydocstring) :call pydocstring#insert()<CR>
-if !hasmapto('<Plug>(pydocstring)')
-  nmap <silent> <C-l> <Plug>(pydocstring)
+if !exists('g:pydocstring_enable_mapping')
+  let g:pydocstring_enable_mapping = 1
+endif
+
+if g:pydocstring_enable_mapping == 1 || hasmapto('<Plug>(pydocstring)')
+  nnoremap <silent> <buffer> <Plug>(pydocstring) :call pydocstring#insert()<CR>
+  if !hasmapto('<Plug>(pydocstring)')
+    nmap <silent> <C-l> <Plug>(pydocstring)
+  endif
 endif
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Add new option to allow users to disable mappings entirely. Previously, users
only had the option to override the default mapping with another one.

I don't personally use this feature enough to justify a mapping. I prefer to only have the `:Pydocstring` command. I can undo the default mapping easily enough, but not without creating another mapping, which doesn't really solve the problem the way I'd like.

Awesome plugin overall though! This is the only feature bugging me so far.