### PR TITLE
add expand to allow relative path

### DIFF
--- a/autoload/pydocstring.vim
+++ b/autoload/pydocstring.vim
@@ -31,7 +31,7 @@ let s:regexs = {
 \ }
 
 function! s:readtmpl(type)
-  let path = s:tmpldir . a:type . '.txt'
+  let path = expand(s:tmpldir . a:type . '.txt')
   if !filereadable(path)
     throw 'Template ' . path . ' is not exists.'
   endif


### PR DESCRIPTION
Hey, I am using your excellent plugin but hit an issue. 

In order to make my dotfile portable, i am using "~/[some path]" as template path but the script complains that it cannot find the file.

I am adding `expand` to the path so it will work both ways.

Let me know if it looks good to you.