### PR TITLE
Fix #17

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Version 0.1.1
+-------------
+Released on Feb 12th 2017
+
+- Fix bug
+  If none typed arg, lack of last `:`.
+  see https://github.com/heavenshell/vim-pydocstring/issues/17
+
 Version 0.1.0
 -------------
 Released on Dec 25th 2016

--- a/doc/pydocstring.txt
+++ b/doc/pydocstring.txt
@@ -1,6 +1,6 @@
 *pydocstring.txt*	Generate Python docstring to your Python code.
 
-Version: 0.1.0
+Version: 0.1.1
 Author: Shinya Ohynagi <sohyanagi@gmail.com>
 Repository: http://github.com/heavenshell/vim-pydocstring/
 License: BSD, see LICENSE for more details.

--- a/ftplugin/python/pydocstring.vim
+++ b/ftplugin/python/pydocstring.vim
@@ -1,6 +1,6 @@
 " File:     pydocstring.vim
 " Author:   Shinya Ohyanagi <sohyanagi@gmail.com>
-" Version:  0.1.0
+" Version:  0.1.1
 " WebPage:  http://github.com/heavenshell/vim-pydocstriong/
 " Description: Generate Python docstring to your Python script file.
 " License: BSD, see LICENSE for more details.

--- a/template/pydocstring/multi.txt
+++ b/template/pydocstring/multi.txt
@@ -1,4 +1,4 @@
 """{{_header_}}
-:param {{_args_}}
+:param {{_args_}}:
 :rtype: {{_returnType_}}
 """

--- a/test/type-hint.vader
+++ b/test/type-hint.vader
@@ -25,7 +25,7 @@ Expect python:
     def foo(sample_var) -> str:
         """foo
 
-        :param sample_var
+        :param sample_var:
 
         :rtype: str
         """
@@ -41,8 +41,8 @@ Expect python:
     def foo(arg1, arg2) -> str:
         """foo
 
-        :param arg1
-        :param arg2
+        :param arg1:
+        :param arg2:
 
         :rtype: str
         """
@@ -100,7 +100,7 @@ Expect python:
 
         :param n:
         :type n: int
-        :param arg
+        :param arg:
 
         :rtype: int
         """


### PR DESCRIPTION
Fix lack of end `:`.
https://github.com/heavenshell/vim-pydocstring/issues/17