### PR TITLE
Solved exception: Template does not exist

### DIFF
--- a/autoload/pydocstring.vim
+++ b/autoload/pydocstring.vim
@@ -35,9 +35,9 @@ function! s:readtmpl(type)
     let tmpldir =  tmpldir . '/'
   endif
 
-  let path = expand(tmpldir . a:type . '.txt')
+  let path = expand(tmpldir) . a:type . '.txt'
   if !filereadable(path)
-    throw 'Template ' . path . ' is not exists.'
+    throw 'Template ' . path . ' does not exist.'
   endif
   let tmpl = readfile(path, 'b')
   return tmpl


### PR DESCRIPTION
For some reason, I added set wildignore=*.txt in my vimrc, which caused expand('/path/to/file.txt') failure, so only expand tmpldir instead of full path.