### PR TITLE
Fix dict params include bug

### DIFF
--- a/autoload/pydocstring.vim
+++ b/autoload/pydocstring.vim
@@ -174,7 +174,6 @@ function! s:parse_func(type, line)
 
   let args_str = substitute(a:line, '\s\|.*(\|).*', '', 'g')
   if args_str =~ ':' && args_str =~ '['
-    echomsg match(args_str, '[A-z0-9_$]\+:')
     if match(args_str, '[A-z0-9_$]\+:') >= 0
       let args = s:parse_args_with_types(args_str)
     else

--- a/test/issue_with_dict.vader
+++ b/test/issue_with_dict.vader
@@ -1,0 +1,87 @@
+# vim:set et sw=4 ts=4 tw=79:
+Given python (def foo with dict params):
+    def get_adjacency(
+        facets,
+        points=None,
+        max_degree=None,
+        dtypes={'ints': np.int64, 'floats': np.float32},
+    ):
+        pass
+
+Execute:
+    Pydocstring
+
+Expect python:
+    def get_adjacency(
+        facets,
+        points=None,
+        max_degree=None,
+        dtypes={'ints': np.int64, 'floats': np.float32},
+    ):
+        """get_adjacency
+
+        :param facets:
+        :param points:
+        :param max_degree:
+        :param dtypes:
+        """
+        pass
+
+Given python (def foo with list params):
+    def get_adjacency(
+        facets,
+        points=None,
+        max_degree=None,
+        dtypes=['ints', 'floats'],
+    ):
+        pass
+
+Execute:
+    Pydocstring
+
+Expect python:
+    def get_adjacency(
+        facets,
+        points=None,
+        max_degree=None,
+        dtypes=['ints', 'floats'],
+    ):
+        """get_adjacency
+
+        :param facets:
+        :param points:
+        :param max_degree:
+        :param dtypes:
+        """
+        pass
+
+Given python (def foo with list and dict params):
+    def get_adjacency(
+        facets,
+        points=None,
+        max_degree=None,
+        dtypes={'ints': np.int64, 'floats': np.float32},
+        etypes=['ints', 'floats'],
+    ):
+        pass
+
+Execute:
+    Pydocstring
+
+Expect python:
+    def get_adjacency(
+        facets,
+        points=None,
+        max_degree=None,
+        dtypes={'ints': np.int64, 'floats': np.float32},
+        etypes=['ints', 'floats'],
+    ):
+        """get_adjacency
+
+        :param facets:
+        :param points:
+        :param max_degree:
+        :param dtypes:
+        :param etypes:
+        """
+        pass


### PR DESCRIPTION
#61 

Note: currently still bugging...

tuple keyword arguments
```python
def foo(arg, arg2=(1, 2)):
    """foo

    :param 1:
    :param 2:
     pass
```