### PR TITLE
Add README note regarding vim-plug and venv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ You can install following command.
   $ make install
 
 
-This can be automated with vim-plug.
+This can be automated with vim-plug. Activated venv needs to be deactivated before running `PlugInstall` or `PlugUpdate`. 
 
 .. code::
 
@@ -39,7 +39,7 @@ If you want install doq manually, you can install from PyPi.
   $ python3 -m venv ./venv
   $ ./venv/bin/pip3 install doq
 
-Than set installed `doq <https://pypi.org/project/doq/>`_ path to `g:pydocstring_doq_path`.
+Then set installed `doq <https://pypi.org/project/doq/>`_ path to `g:pydocstring_doq_path`.
 
 Note
 ~~~~


### PR DESCRIPTION
I was using `Plug 'heavenshell/vim-pydocstring', { 'for': ['python'], 'do': 'make install' }` to install the plugin via vim-plug and was receiving the `'doq' not found.Install 'doq'` error when attempting to run `:Pydocstring`. It looks like the MakeFile creates a new venv for installing doq, so exits if there is an active venv. So, if the `PlugInstall` or `PlugUpdate` vim-plug commands were ran within a venv, doq would not install. I made a note of this in the README and fixed a grammar mistake.