### PR TITLE
Fix rst syntax error in README.md to make the instructions about the …

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,7 @@ If you want install doq manually, you can install from PyPi.
 Then set installed `doq <https://pypi.org/project/doq/>`_ path:
 
 .. code::
+
     $ which doq
     g:pydocstring_doq_path
 


### PR DESCRIPTION
**Fixed a but with the rendering of the `README.rst` in this PR.**

##  Issue
The instructions on how to configure the path to the `doq` binary in the `.vimrc` weren't rendered properly in the `README.rst`.
> Missing part:
>  ```
>    $ which doq
>    g:pydocstring_doq_path
> ```

I encountered this bug today, but I think the author of [this issue](https://github.com/heavenshell/vim-pydocstring/issues/98) has experienced the same problem.
> That issue is 9 days old, while the bug has been present for at least 19 days  (see [this commit](https://github.com/heavenshell/vim-pydocstring/commit/b14ef92cac19168a7b9d2bc52f18bfb460133e88#diff-88b99bb28683bd5b7e3a204826ead112))

## Cause

A new line character was missing from the `README.rst` after a `code` directive and the lines in the code block were interpreted as arguments for the `code` directive as a result.

## Note
By the way, it's a pretty cool plugin, thank you! ☺️ 
