### PR TITLE
Fixed default mapping value in documentation 

### DIFF
--- a/doc/pydocstring.txt
+++ b/doc/pydocstring.txt
@@ -202,7 +202,7 @@ g:pydocstring_enable_mapping			*g:pydocstring_enable_mapping*
 
     nmap <silent> <C-m> <Plug>(pydocstring)
 
-		Default value is '1'
+		Default value is 'l'
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:fdl=0:

--- a/doc/pydocstring.txt
+++ b/doc/pydocstring.txt
@@ -202,7 +202,7 @@ g:pydocstring_enable_mapping			*g:pydocstring_enable_mapping*
 
     nmap <silent> <C-m> <Plug>(pydocstring)
 
-		Default value is 'l'
+		Default value is 'n'
 
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:fdl=0:

--- a/ftplugin/python/pydocstring.vim
+++ b/ftplugin/python/pydocstring.vim
@@ -20,7 +20,7 @@ command! -buffer -nargs=0 PydocstringFormat call pydocstring#format()
 nnoremap <silent> <buffer> <Plug>(pydocstring) :call pydocstring#insert()<CR>
 if get(g:, 'pydocstring_enable_mapping', 1)
   if !hasmapto('<Plug>(pydocstring)', 'n')
-    nmap <silent> <buffer> <C-l> <Plug>(pydocstring)
+    nmap <silent> <buffer> <C-n> <Plug>(pydocstring)
   endif
 endif
 


### PR DESCRIPTION
Fixed default  value in documentation  to match actual default value for nmap. The [actual default value is l (lowercase L) ](,https://github.com/heavenshell/vim-pydocstring/blob/e3d411821cfb5fa06b8cc18d6a3f0cccfde2bf7d/ftplugin/python/pydocstring.vim#L23) and not 1 (one) as presented in the documentation  . Additionally, <C-l> is the default mapping to switch to the left on horizontal split screen, so another default mapping might be better. 